### PR TITLE
CV Media Parser - Take 1

### DIFF
--- a/packager/media/demuxer/demuxer.cc
+++ b/packager/media/demuxer/demuxer.cc
@@ -16,6 +16,7 @@
 #include "packager/media/base/media_sample.h"
 #include "packager/media/base/stream_info.h"
 #include "packager/media/file/file.h"
+#include "packager/media/formats/cv/cv_media_parser.h"
 #include "packager/media/formats/mp2t/mp2t_media_parser.h"
 #include "packager/media/formats/mp4/mp4_media_parser.h"
 #include "packager/media/formats/webm/webm_media_parser.h"
@@ -165,6 +166,7 @@ Status Demuxer::InitializeParser() {
                   "Cannot open file for reading " + file_name_);
   }
 
+  /*
   // Read enough bytes before detecting the container.
   int64_t bytes_read = 0;
   while (static_cast<size_t>(bytes_read) < kInitBufSize) {
@@ -199,11 +201,14 @@ Status Demuxer::InitializeParser() {
       NOTIMPLEMENTED();
       return Status(error::UNIMPLEMENTED, "Container not supported.");
   }
+  */
 
+  parser_.reset(new cv::CVMediaParser());
   parser_->Init(base::Bind(&Demuxer::ParserInitEvent, base::Unretained(this)),
                 base::Bind(&Demuxer::NewSampleEvent, base::Unretained(this)),
                 key_source_.get());
 
+  /*
   // Handle trailing 'moov'.
   if (container_name_ == CONTAINER_MOV)
     static_cast<mp4::MP4MediaParser*>(parser_.get())->LoadMoov(file_name_);
@@ -211,6 +216,7 @@ Status Demuxer::InitializeParser() {
     return Status(error::PARSER_FAILURE,
                   "Cannot parse media file " + file_name_);
   }
+  */
   return Status::OK;
 }
 

--- a/packager/media/formats/cv/cv_media_parser.cc
+++ b/packager/media/formats/cv/cv_media_parser.cc
@@ -26,11 +26,25 @@
 #include "packager/media/file/file.h"
 #include "packager/media/file/file_closer.h"
 
+namespace
+{
+	const int kMagicHeaderSize = 4;
+	const int kFrameHeaderSize = 5;
+	const uint32_t kMagicBytes = 0xDEADBEEF;
+
+	uint32_t Read32(uint8_t *buf)
+	{
+		return buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3];
+	}
+}
+
 namespace shaka {
 namespace media {
 namespace cv {
 	
-CVMediaParser::CVMediaParser() {}
+CVMediaParser::CVMediaParser() :
+	state_(kParsingMagic), key_frame_(false), frame_size_(0), pts_(0)
+{}
 
 CVMediaParser::~CVMediaParser() {}
 
@@ -43,6 +57,26 @@ void CVMediaParser::Init(const InitCB& init_cb,
 
 	init_cb_ = init_cb;
 	new_sample_cb_ = new_sample_cb;
+
+	std::vector<std::shared_ptr<StreamInfo>> streams;
+	// Should be like 33333333
+	uint32_t timescale = 1 / 30 * (10 >> 8);
+	uint64_t duration = 0;
+	std::string codec = "";
+	uint16_t codedWidth = 1920;
+	uint16_t codedHeight = 1080;
+	uint32_t pixelWidth = 0;
+	uint32_t pixelHeight = 0;
+	// We do not have NAL unit length prefixes (I don’t think)
+	uint8_t nalUnitLengthSize = 0;
+
+	std::shared_ptr<VideoStreamInfo> video_stream_info(new VideoStreamInfo(0, timescale,
+		duration, Codec::kCodecH264, H26xStreamFormat::kNalUnitStreamWithoutParameterSetNalus,
+		codec, nullptr, 0, codedWidth, codedHeight, pixelWidth, pixelHeight, 0, nalUnitLengthSize,
+		std::string(), false));
+
+	streams.push_back(video_stream_info);
+	init_cb_.Run(streams);
 }
 
 bool CVMediaParser::Flush() {
@@ -50,6 +84,77 @@ bool CVMediaParser::Flush() {
 }
 
 bool CVMediaParser::Parse(const uint8_t* buf, int size) {
+	// Expand our buffer
+	size_t current_size = buffer_.size();
+	buffer_.resize(current_size + size);
+
+	// Copy new data to the back
+	memcpy(&buffer_[current_size], buf, size);
+
+	// Parsing magic bytes
+	if (state_ == State::kParsingMagic && buffer_.size() >= kMagicHeaderSize)
+	{
+		// Grab the bytes
+		uint32_t magicBytes = Read32(&buffer_[0]);
+		if (magicBytes == kMagicBytes)
+		{
+			// All good, change state and clear data
+			state_ = State::kParsingHeader;
+			buffer_.erase(buffer_.begin(), buffer_.begin() + kMagicHeaderSize);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	// Parsing header
+	if (state_ == State::kParsingHeader && buffer_.size() >= kFrameHeaderSize)
+	{
+		// Get the data
+		// {1:0|1} - key frame flag
+		// {4:size} - nalu size
+		key_frame_ = buffer_[0] == 1 ? true : false;
+		frame_size_ = Read32(&buffer_[1]);
+		// Sanity check the frame size?
+		if (frame_size_ > 0)
+		{
+			// All good, change state and clear data
+			state_ = State::kParsingNal;
+			buffer_.erase(buffer_.begin(), buffer_.begin() + kFrameHeaderSize);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	// Parsing NALU frame
+	if (state_ == State::kParsingNal && buffer_.size() >= frame_size_)
+	{
+		std::shared_ptr<MediaSample> stream_sample(
+			MediaSample::CopyFrom(&buffer_[0], frame_size_, key_frame_));
+		
+		uint64_t ts = pts_++;
+		stream_sample->set_dts(ts);
+		stream_sample->set_pts(ts);
+		uint64_t duration = 33333333;
+		stream_sample->set_duration(duration);
+
+		DVLOG(3) << "Pushing frame: "
+			<< ", key=" << stream_sample->is_key_frame()
+			<< ", dur=" << stream_sample->duration()
+			<< ", dts=" << stream_sample->dts()
+			<< ", pts=" << stream_sample->pts()
+			<< ", size=" << stream_sample->data_size();
+
+		if (!new_sample_cb_.Run(0, stream_sample)) {
+			LOG(ERROR) << "Failed to process the sample.";
+			return false;
+		}
+		// All good, change state and clear data
+		state_ = State::kParsingHeader;
+		buffer_.erase(buffer_.begin(), buffer_.begin() + frame_size_);
+	}
+
 	return true;
 }
 	

--- a/packager/media/formats/cv/cv_media_parser.cc
+++ b/packager/media/formats/cv/cv_media_parser.cc
@@ -73,106 +73,121 @@ bool CVMediaParser::Parse(const uint8_t* buf, int size) {
 	// Copy new data to the back
 	memcpy(&buffer_[current_size], buf, size);
 
-	// Parsing magic bytes
-	if (state_ == State::kParsingMagic && buffer_.size() >= kMagicHeaderSize)
+
+	while ((state_ == State::kParsingMagic && buffer_.size() >= kMagicHeaderSize) ||
+		(state_ == State::kParsingHeader && buffer_.size() >= kFrameHeaderSize) ||
+		((state_ == State::kWaitingInit || state_ == State::kParsingNal) &&
+			buffer_.size() >= frame_size_))
 	{
-		// Grab the bytes
-		uint32_t magicBytes = Read32(&buffer_[0]);
-		if (magicBytes == kMagicBytes)
+
+		// Parsing magic bytes
+		if (state_ == State::kParsingMagic && buffer_.size() >= kMagicHeaderSize)
 		{
-			// All good, change state and clear data
-			state_ = State::kParsingHeader;
-			buffer_.erase(buffer_.begin(), buffer_.begin() + kMagicHeaderSize);
-		}
-		else
-		{
-			return false;
-		}
-	}
-	// Parsing header
-	if (state_ == State::kParsingHeader && buffer_.size() >= kFrameHeaderSize)
-	{
-		// Get the data
-		// {1:0|1} - key frame flag
-		// {4:size} - nalu size
-		key_frame_ = buffer_[0] == 1 ? true : false;
-		frame_size_ = Read32(&buffer_[1]);
-		// Sanity check the frame size?
-		if (frame_size_ > 0)
-		{
-			// All good, change state and clear data
-			state_ = got_config_ ? State::kParsingNal : State::kWaitingInit;
-			buffer_.erase(buffer_.begin(), buffer_.begin() + kFrameHeaderSize);
-		}
-		else
-		{
-			return false;
-		}
-	}
-	// Parsing NALU frame
-	if ((state_ == State::kWaitingInit || state_ == State::kParsingNal) &&
-		buffer_.size() >= frame_size_)
-	{
-		if (state_ == State::kWaitingInit)
-		{
-			// TODO: Figure out SPS and PPS length?
-			std::vector<uint8_t> sps_pps(buffer_.begin(), buffer_.begin() + kSpsPpsSize);
-			AVCDecoderConfigurationRecord avc_config;
-			if (!avc_config.Parse(sps_pps)) {
-				LOG(ERROR) << "Failed to parse avcc.";
+			// Grab the bytes
+			uint32_t magicBytes = Read32(&buffer_[0]);
+			if (magicBytes == kMagicBytes)
+			{
+				// All good, change state and clear data
+				state_ = State::kParsingHeader;
+				buffer_.erase(buffer_.begin(), buffer_.begin() + kMagicHeaderSize);
+			}
+			else
+			{
 				return false;
 			}
+		}
+		// Parsing header
+		if (state_ == State::kParsingHeader && buffer_.size() >= kFrameHeaderSize)
+		{
+			// Get the data
+			// {1:0|1} - key frame flag
+			// {4:size} - nalu size
+			key_frame_ = buffer_[0] == 1 ? true : false;
+			frame_size_ = Read32(&buffer_[1]);
+			// Sanity check the frame size?
+			if (frame_size_ > 0)
+			{
+				// All good, change state and clear data
+				state_ = got_config_ ? State::kParsingNal : State::kWaitingInit;
+				buffer_.erase(buffer_.begin(), buffer_.begin() + kFrameHeaderSize);
+			}
+			else
+			{
+				return false;
+			}
+		}
+		// Parsing NALU frame
+		if ((state_ == State::kWaitingInit || state_ == State::kParsingNal) &&
+			buffer_.size() >= frame_size_)
+		{
+			if (state_ == State::kWaitingInit)
+			{
+				// TODO: Figure out SPS and PPS length?
+				std::vector<uint8_t> sps_pps(buffer_.begin(), buffer_.begin() + kSpsPpsSize);
 
-			std::string codec_string = avc_config.GetCodecString(FOURCC_avc1);
-			uint8_t nalu_length_size = avc_config.nalu_length_size();
-			uint16_t coded_width = avc_config.coded_width();
-			uint16_t coded_height = avc_config.coded_height();
-			uint32_t pixel_width = avc_config.pixel_width();
-			uint32_t pixel_height = avc_config.pixel_height();
+				AVCDecoderConfigurationRecord avc_config;
+				/*
+				if (!avc_config.Parse(sps_pps)) {
+					LOG(ERROR) << "Failed to parse avcc.";
+					return false;
+				}
+				*/
 
-			// Should be like 33333333
-			uint32_t timescale = 1 / 30 * (10 >> 8);
-			uint64_t duration = 0;
-			
-			std::shared_ptr<VideoStreamInfo> video_stream_info(new VideoStreamInfo(0, timescale,
-				duration, Codec::kCodecH264, H26xStreamFormat::kNalUnitStreamWithoutParameterSetNalus,
-				codec_string, &sps_pps[0], sps_pps.size(), coded_width, coded_height, pixel_width, pixel_height, 0, nalu_length_size,
-				std::string(), false));
+				// See: https://wiki.whatwg.org/wiki/Video_type_parameters
+				// See: https://en.wikipedia.org/wiki/H.264/MPEG-4_AVC
+				// This string means avc1, baseline (66 decimal -> 42 hex), something??, level (40 decimal -> 28 hex) which is for 1080p
+				std::string codec_string = "avc1.42c01f";// avc_config.GetCodecString(FOURCC_avc1);
+				uint8_t nalu_length_size = 0; // avc_config.nalu_length_size();
+				uint16_t coded_width = 1920; //avc_config.coded_width();
+				uint16_t coded_height = 1080; //avc_config.coded_height();
+				uint32_t pixel_width = 0; //avc_config.pixel_width();
+				uint32_t pixel_height = 0; //avc_config.pixel_height();
 
-			std::vector<std::shared_ptr<StreamInfo>> streams;
-			streams.push_back(video_stream_info);
-			init_cb_.Run(streams);
+				// Who knows
+				uint32_t timescale = 15360;
+				uint64_t duration = timescale * 60 * 10 * 30;
 
+				std::shared_ptr<VideoStreamInfo> video_stream_info(new VideoStreamInfo(0, timescale,
+					duration, Codec::kCodecH264, H26xStreamFormat::kNalUnitStreamWithoutParameterSetNalus,
+					codec_string, sps_pps.data(), sps_pps.size(), coded_width, coded_height, pixel_width, pixel_height, 0, nalu_length_size,
+					std::string(), false));
+
+				std::vector<std::shared_ptr<StreamInfo>> streams;
+				streams.push_back(video_stream_info);
+				init_cb_.Run(streams);
+
+				// All good, change state and clear data
+				state_ = State::kParsingNal;
+				buffer_.erase(buffer_.begin(), buffer_.begin() + kSpsPpsSize);
+				frame_size_ -= kSpsPpsSize;
+				got_config_ = true;
+			}
+
+			std::shared_ptr<MediaSample> stream_sample(
+				MediaSample::CopyFrom(&buffer_[0], frame_size_, key_frame_));
+
+			uint64_t ts = pts_++;
+			stream_sample->set_dts(ts);
+			stream_sample->set_pts(ts);
+			uint64_t duration = 512;
+			stream_sample->set_duration(duration);
+
+			DVLOG(3) << "Pushing frame: "
+				<< ", key=" << stream_sample->is_key_frame()
+				<< ", dur=" << stream_sample->duration()
+				<< ", dts=" << stream_sample->dts()
+				<< ", pts=" << stream_sample->pts()
+				<< ", size=" << stream_sample->data_size();
+
+			if (!new_sample_cb_.Run(0, stream_sample)) {
+				LOG(ERROR) << "Failed to process the sample.";
+				return false;
+			}
 			// All good, change state and clear data
-			state_ = State::kParsingNal;
-			buffer_.erase(buffer_.begin(), buffer_.begin() + kSpsPpsSize);
-			frame_size_ -= kSpsPpsSize;
-			got_config_ = true;
+			state_ = State::kParsingHeader;
+			buffer_.erase(buffer_.begin(), buffer_.begin() + frame_size_);
 		}
 
-		std::shared_ptr<MediaSample> stream_sample(
-			MediaSample::CopyFrom(&buffer_[0], frame_size_, key_frame_));
-		
-		uint64_t ts = pts_++;
-		stream_sample->set_dts(ts);
-		stream_sample->set_pts(ts);
-		uint64_t duration = 33333333;
-		stream_sample->set_duration(duration);
-
-		DVLOG(3) << "Pushing frame: "
-			<< ", key=" << stream_sample->is_key_frame()
-			<< ", dur=" << stream_sample->duration()
-			<< ", dts=" << stream_sample->dts()
-			<< ", pts=" << stream_sample->pts()
-			<< ", size=" << stream_sample->data_size();
-
-		if (!new_sample_cb_.Run(0, stream_sample)) {
-			LOG(ERROR) << "Failed to process the sample.";
-			return false;
-		}
-		// All good, change state and clear data
-		state_ = State::kParsingHeader;
-		buffer_.erase(buffer_.begin(), buffer_.begin() + frame_size_);
 	}
 
 	return true;

--- a/packager/media/formats/cv/cv_media_parser.h
+++ b/packager/media/formats/cv/cv_media_parser.h
@@ -2,6 +2,7 @@
 #define MEDIA_FORMATS_CV_CV_MEDIA_PARSER_H_
 
 #include <stdint.h>
+#include <vector>
 
 #include "packager/media/base/media_parser.h"
 
@@ -24,8 +25,20 @@ class CVMediaParser : public MediaParser {
   /// @}
 
  private:
+	 enum State
+	 {
+		 kParsingMagic,
+		 kParsingHeader,
+		 kParsingNal
+	 };
+
 	 InitCB init_cb_;
 	 NewSampleCB new_sample_cb_;
+	 State state_;
+	 bool key_frame_;
+	 uint32_t frame_size_;
+	 uint64_t pts_;
+	 std::vector<uint8_t> buffer_;
 };
 	
 }  // namespace cv

--- a/packager/media/formats/cv/cv_media_parser.h
+++ b/packager/media/formats/cv/cv_media_parser.h
@@ -27,6 +27,7 @@ class CVMediaParser : public MediaParser {
  private:
 	 enum State
 	 {
+		 kWaitingInit,
 		 kParsingMagic,
 		 kParsingHeader,
 		 kParsingNal
@@ -34,6 +35,7 @@ class CVMediaParser : public MediaParser {
 
 	 InitCB init_cb_;
 	 NewSampleCB new_sample_cb_;
+	 bool got_config_;
 	 State state_;
 	 bool key_frame_;
 	 uint32_t frame_size_;


### PR DESCRIPTION
It definitely parses and generates output and doesn't blow up. Yet... The browser will attempt to play it and ultimately say it cannot decode.

Few things that I am not sure of:
- Timescale and duration, especially for live content. What should the duration be here?
- Codec string. I hard coded some previously known working ones. I understand the avc_level and profile, but not the compatibility thingy.
- The codec configuration data is most likely what is screwing it up. The downstream muxer expects everything to be MP4 style. Hence my attempt to use the AVCDecoderConfigurationRecord. This only works if we read in from a MP4, though. I am not sure if we can manually build what this is expecting.

Further TODOs:
1. Make the Demuxer properly determine the container format to select the parser automatically. That way we can use the packager on .mp4s without recompiling.
2. Erasing from the front of the vector is not super stellar, or fast, or memory efficient.
3. The parse method should be decomposed into smaller methods.